### PR TITLE
image.sh: fix issues with grub-install

### DIFF
--- a/scripts/image.sh
+++ b/scripts/image.sh
@@ -108,11 +108,11 @@ if [ ! "$USE_EXISTING" ]; then
     msg "Installing grub..."
     GRUB_COMMAND="grub2-install"
     GRUB_EXTRAARGS="--force"
-    if ! type "$GRUB_COMMAND" > /dev/null; then
+    if ! type "$GRUB_COMMAND" &> /dev/null; then
         GRUB_COMMAND="grub-install"
         GRUB_EXTRAARGS=""
     fi
-    "$GRUB_COMMAND" --boot-directory=mnt/boot --target=i386-pc --modules="ext2 part_msdos" "${dev}" "$GRUB_EXTRAARGS" || fail "Couldn't install grub."
+    "$GRUB_COMMAND" --boot-directory=mnt/boot --target=i386-pc --modules="ext2 part_msdos" "${dev}" $GRUB_EXTRAARGS || fail "Couldn't install grub."
     cp "${SOURCE_DIR}/scripts/grub.cfg" mnt/boot/grub || fail "Couldn't copy grub.cfg."
   fi
 fi


### PR DESCRIPTION
fixes #5 

The ampersand character is added to properly check for grub2-install.

Additionally, the quotations around  `GRUB_EXTRAARGS` are removed from the grub-install call, as - when empty, as is the default if grub-install is present - they were misinterpreted by grub causing an error when building the image.