### PR TITLE
Exclude cmake-build folder from IDEA/CLion.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,6 +7,7 @@
       <file path="$PROJECT_DIR$/src" />
     </sourceRoots>
     <excludeRoots>
+      <file path="$PROJECT_DIR$/cmake-build" />
       <file path="$PROJECT_DIR$/toolchain" />
     </excludeRoots>
   </component>


### PR DESCRIPTION
This makes opening the project faster as it doesn't have to index the downloaded tarballs(?).