### PR TITLE
[WIP] Vagrant Build Machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,9 @@ _deps
 # CMake
 cmake-build*/
 
+# Vagrant
+/.Vagrant
+
 #
 # DUCKOS-SPECIFIC
 #

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,4 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision "shell", path: "scripts/vagrant-init.sh";
+end

--- a/scripts/vagrant-init.sh
+++ b/scripts/vagrant-init.sh
@@ -1,4 +1,11 @@
+#!/bin/bash
+
 cd /vagrant
+
+# Needed for running scripts correctly.
+sudo apt-get install dos2unix -y
+find scripts/*.sh -type f -exec dos2unix {} \;
+find toolchain/*.sh -type f -exec dos2unix {} \;
 
 sudo locale-gen UTF-8
 
@@ -9,9 +16,11 @@ sudo apt install build-essential cmake bison flex libgmp3-dev libmpc-dev libmpfr
 
 export CMAKE_ASM_NASM_COMPILER=nasm
 
+export IS_VAGRANT=1
+
 cd toolchain
-chmod a+x ./build-toolchain.sh
-bash build-toolchain.sh
+chmod +x ./build-toolchain.sh
+source "build-toolchain.sh"
 
 cd ../
 mkdir -p cmake-build

--- a/scripts/vagrant-init.sh
+++ b/scripts/vagrant-init.sh
@@ -1,0 +1,19 @@
+cd /vagrant
+
+sudo locale-gen UTF-8
+
+sudo apt-get install software-properties-common -y
+sudo add-apt-repository ppa:george-edison55/cmake-3.x -y
+sudo apt update -y
+sudo apt install build-essential cmake bison flex libgmp3-dev libmpc-dev libmpfr-dev texinfo qemu-system-i386 qemu-utils nasm gawk grub2-common grub-pc rsync -y
+
+export CMAKE_ASM_NASM_COMPILER=nasm
+
+cd toolchain
+chmod a+x ./build-toolchain.sh
+bash build-toolchain.sh
+
+cd ../
+mkdir -p cmake-build
+cd cmake-build
+cmake .. -DCMAKE_TOOLCHAIN_FILE=toolchain/CMakeToolchain.txt

--- a/toolchain/build-toolchain.sh
+++ b/toolchain/build-toolchain.sh
@@ -1,6 +1,25 @@
 #!/bin/bash
 set -e
 
+# Some enviroments may not have 'realpath'
+if ! command -v realpath &> /dev/null
+then
+  realpath ()
+  {
+    f=$@;
+    if [ -d "$f" ]; then
+      base="";
+      dir="$f";
+    else
+      base="/$(basename "$f")";
+      dir=$(dirname "$f");
+    fi;
+    dir=$(cd "$dir" && /bin/pwd);
+    echo "$dir$base"
+  }
+fi
+
+
 source "./toolchain-common.sh"
 source "../scripts/duckos.sh"
 

--- a/toolchain/toolchain-common.sh
+++ b/toolchain/toolchain-common.sh
@@ -33,7 +33,7 @@ fi
 download-binutils () {
   if [ ! -d "$BINUTILS_FILE" ]; then
     msg "Downloading binutils $BINUTILS_VERSION..."
-    curl "$BINUTILS_URL" > "$BINUTILS_FILE.tar.gz" || exit 1
+    curl -k "$BINUTILS_URL" > "$BINUTILS_FILE.tar.gz" || exit 1
     msg "Extracting binutils..."
     tar -xzf "$BINUTILS_FILE.tar.gz" || exit 1
     rm "$BINUTILS_FILE.tar.gz"
@@ -58,7 +58,7 @@ download-binutils () {
 download-gcc () {
   if [ ! -d "$GCC_FILE" ]; then
     msg "Downloading gcc $GCC_VERSION..."
-    curl "$GCC_URL" > "$GCC_FILE.tar.gz" || exit 1
+    curl -k "$GCC_URL" > "$GCC_FILE.tar.gz" || exit 1
     msg "Extracting gcc..."
     tar -xzf "$GCC_FILE.tar.gz" || exit 1
     rm "$GCC_FILE.tar.gz"


### PR DESCRIPTION
Vagrant is a nice little VM provisioner. It would allow us to create a consistent build environment which works for everyone. This is still work in progress.
Currently it looks like the new `vagrant-init` script ignores building of the toolchain. This ends up with `cmake .. etc` not able to find a compiler.
You may try it and have a look, if you want.